### PR TITLE
Change 2019 Blockchain Week dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ description: Berlin Blockchain Week is a community-organized initiative. We
   individuals and anyone interested in fruitful and educational discussions to
   join us.
 
-tagline: 20-29th August 2019
+tagline: 19-29th August 2019
 
 features:
 - title: Full Node


### PR DESCRIPTION
**Change:**

Change from "20-29th" to "19-29th"

**Reasons**
- MetaCartel Demo Day is on the Monday 19th, which kicks off the Berlin Blockchain Week
- 20th is a Tuesday. 19th is a Monday. Why does it start on a Tuesday. Monday is also a perfectly fine weekday.

